### PR TITLE
added capability to append query params to the jdbc connection url

### DIFF
--- a/lib/jdbc-helper/connection.rb
+++ b/lib/jdbc-helper/connection.rb
@@ -145,6 +145,10 @@ class Connection
 
     @driver = args.delete :driver
     @url = args.delete :url
+    if args.has_key? :query
+      @url += "?#{args[:query].to_query}"
+      args.delete :query
+    end
 
     timeout = args.has_key?(:timeout) ? args.delete(:timeout) : Constants::DEFAULT_LOGIN_TIMEOUT
     if timeout


### PR DESCRIPTION
Hey I juse added a few lines to support query parameters for the jdbc connection string, you can now use something like this:

 JDBCHelper::MySQL.connect host, user, password, db, {:query => {:useSSL => false}}

Cheers
